### PR TITLE
Discord user integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ GUILD_IDS: [123, 456]
 
 - Open and login to the `League of Legends` client. It needs to be open to scrape local custom game match history data.
 
-- From the project home directory run `python inhouse_bot.py` to start the Discord bot.
+- From the project root directory run `python inhouse_bot.py` to start the Discord bot.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ GUILD_IDS: [123, 456]
 
 - Open and login to the `League of Legends` client. It needs to be open to scrape local custom game match history data.
 
-- From the `scripts` directory run `python inhouse_bot.py` to start the Discord bot.
+- From the project home directory run `python inhouse_bot.py` to start the Discord bot.

--- a/scripts/classes/ChampionStats.py
+++ b/scripts/classes/ChampionStats.py
@@ -1,4 +1,4 @@
-from classes.PlayerGameStats import PlayerGameStats
+from scripts.classes.PlayerGameStats import PlayerGameStats
 
 
 class ChampionStats:

--- a/scripts/classes/Game.py
+++ b/scripts/classes/Game.py
@@ -1,14 +1,17 @@
-from classes.PlayerGameStats import PlayerGameStats
+from scripts.classes.PlayerGameStats import PlayerGameStats
+from scripts.classes.PlayerName import PlayerName
 
 
 class Game:
     def __init__(self, gameId: int, raw_data: dict) -> None:
         self.id: int = gameId
-        self.pmap: dict[int, str] = {}
-        for participant in raw_data["participantIdentities"]:
-            self.pmap[participant["participantId"]] = participant["player"][
-                "summonerName"
-            ]
+        self.pmap: dict[int, PlayerName] = {}
+        for p in raw_data["participantIdentities"]:
+            self.pmap[p["participantId"]] = PlayerName(
+                summonerName=p["player"]["summonerName"],
+                name=p["player"]["gameName"],
+                tag=p["player"]["tagLine"],
+            )
 
         self.team1: list[PlayerGameStats] = []
         self.team2: list[PlayerGameStats] = []

--- a/scripts/classes/Match.py
+++ b/scripts/classes/Match.py
@@ -1,4 +1,4 @@
-from generate_player_stats import Game
+from scripts.generate_player_stats import Game
 
 
 class Match:

--- a/scripts/classes/MatchHistoryMatch.py
+++ b/scripts/classes/MatchHistoryMatch.py
@@ -1,4 +1,4 @@
-from classes.PlayerGameStats import PlayerGameStats
+from scripts.classes.PlayerGameStats import PlayerGameStats
 
 
 class MatchHistoryMatch:

--- a/scripts/classes/PlayerGameStats.py
+++ b/scripts/classes/PlayerGameStats.py
@@ -1,12 +1,11 @@
-from constants import champ_id_map
+from scripts.constants import champ_id_map
+from scripts.classes.PlayerName import PlayerName
 
 
 class PlayerGameStats:
     def __init__(self, raw_stats, pmap, gameId) -> None:
         self.gameId: int = gameId
-        self.playerId: int = raw_stats["participantId"]
-        self.playerName: str = pmap[self.playerId].lower()
-        self.playerDisplayName: str = pmap[self.playerId]
+        self.name: PlayerName = pmap[raw_stats["participantId"]]
         self.championId: int = raw_stats["championId"]
         self.championName: str = champ_id_map[self.championId]
         self.cs: int = (

--- a/scripts/classes/PlayerHistoricalStats.py
+++ b/scripts/classes/PlayerHistoricalStats.py
@@ -1,8 +1,9 @@
-from classes.MatchHistoryMatch import MatchHistoryMatch
-from classes.PlayerGameStats import PlayerGameStats
-from classes.ChampionStats import ChampionStats
-from classes.Teammate import Teammate
-from classes.Game import Game
+from scripts.classes.MatchHistoryMatch import MatchHistoryMatch
+from scripts.classes.PlayerGameStats import PlayerGameStats
+from scripts.classes.ChampionStats import ChampionStats
+from scripts.classes.Teammate import Teammate
+from scripts.classes.Game import Game
+from scripts.classes.PlayerName import PlayerName
 
 import trueskill
 
@@ -24,10 +25,9 @@ class PlayerHistoricalStats:
     totalCs: int = 0
     csPerMin: float = 0
 
-    def __init__(self, playerName: str, playerDisplayName: str) -> None:
+    def __init__(self, name: PlayerName) -> None:
         self.matchHistory: list[MatchHistoryMatch] = []
-        self.playerName: str = playerName
-        self.playerDisplayName: str = playerDisplayName
+        self.name: PlayerName = name
         self.teammates: dict[str, Teammate] = {}
         self.opponents: dict[str, Teammate] = {}
         self.championStats: dict[str, ChampionStats] = {}
@@ -74,23 +74,19 @@ class PlayerHistoricalStats:
         self, win: bool, teammates: dict[str, Teammate], opponents: dict[str, Teammate]
     ):
         for teammate in teammates:
-            if teammate.playerName == self.playerName:
+            if teammate.name.name == self.name.name:
                 continue
 
-            if self.teammates.get(teammate.playerName) is None:
-                self.teammates[teammate.playerName] = Teammate(
-                    teammate.playerDisplayName
-                )
+            if self.teammates.get(teammate.name.name) is None:
+                self.teammates[teammate.name.name] = Teammate(teammate.name)
 
-            self.teammates[teammate.playerName].add_game(win)
+            self.teammates[teammate.name.name].add_game(win)
 
         for opponent in opponents:
-            if self.opponents.get(opponent.playerName) is None:
-                self.opponents[opponent.playerName] = Teammate(
-                    opponent.playerDisplayName
-                )
+            if self.opponents.get(opponent.name.name) is None:
+                self.opponents[opponent.name.name] = Teammate(opponent.name)
 
-            self.opponents[opponent.playerName].add_game(win)
+            self.opponents[opponent.name.name].add_game(win)
 
     def add_game(
         self, game: Game, playerGameStats: PlayerGameStats, mmrDelta: int
@@ -102,7 +98,7 @@ class PlayerHistoricalStats:
         # track teammate and opponent information
         playerTeam = 1
         for player in game.team2:
-            if player.playerName == self.playerName:
+            if player.name.name == self.name.name:
                 playerTeam = 2
                 break
 
@@ -117,7 +113,7 @@ class PlayerHistoricalStats:
 
     def __repr__(self) -> str:
         res = ""
-        res += f"{self.playerName}".ljust(16)
+        res += f"{self.name.name}".ljust(16)
         res += f"{self.wins}W {self.losses}L ({self.winrate}% WR)".ljust(20)
         res += f"KDA: {self.avgKills} / {self.avgDeaths} / {self.avgAssists}".ljust(23)
         res += f"({self.totalkda})".ljust(10)

--- a/scripts/classes/PlayerName.py
+++ b/scripts/classes/PlayerName.py
@@ -1,0 +1,22 @@
+from unicodedata import east_asian_width
+
+
+class PlayerName:
+
+    def __init__(self, summonerName: str, name: str, tag: str) -> None:
+        # check if name has any east asian width characters
+        # if so use summonerName instead and hope it doesnt
+        has_fullwidth = False
+        for c in name:
+            if east_asian_width(c) in ["W", "F", "A"]:
+                has_fullwidth = True
+                break
+        if has_fullwidth:
+            self.name = summonerName.lower()
+            self.displayName = summonerName
+        else:
+            self.name = name.lower()
+            self.displayName = name
+
+        self.summonerName: str = summonerName
+        self.tag: str = tag

--- a/scripts/classes/Teammate.py
+++ b/scripts/classes/Teammate.py
@@ -1,6 +1,9 @@
+from scripts.classes.PlayerName import PlayerName
+
+
 class Teammate:
-    def __init__(self, playerDisplayName: str) -> None:
-        self.playerDisplayName = playerDisplayName
+    def __init__(self, name: PlayerName) -> None:
+        self.name = name
         self.wins = 0
         self.losses = 0
         self.gamesPlayed = 0

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,4 +1,4 @@
-CONFIG_PATH = "../config.yaml"
+CONFIG_PATH = "config.yaml"
 
 champ_id_map = {
     266: "Aatrox",

--- a/scripts/generate_player_stats.py
+++ b/scripts/generate_player_stats.py
@@ -3,11 +3,11 @@ import math
 import trueskill
 from pymongo.database import Database
 
-from constants import CONFIG_PATH
-from classes.PlayerGameStats import PlayerGameStats
-from classes.PlayerHistoricalStats import PlayerHistoricalStats
-from classes.Game import Game
-from utils import load_config, get_database_connection
+from scripts.constants import CONFIG_PATH
+from scripts.classes.PlayerGameStats import PlayerGameStats
+from scripts.classes.PlayerHistoricalStats import PlayerHistoricalStats
+from scripts.classes.Game import Game
+from scripts.utils import load_config, get_database_connection
 
 
 # setup trueskill global environment
@@ -45,15 +45,12 @@ def track_player_stats(
     def __get_team_mmrs(team: list[PlayerGameStats]):
         team_mmrs = {}
         for player_game_stats in team:
-            player_name = player_game_stats.playerName
-            player_display_name = player_game_stats.playerDisplayName
+            name = player_game_stats.name
 
-            if player_name not in player_stats:
-                player_stats[player_name] = PlayerHistoricalStats(
-                    player_name, player_display_name
-                )
+            if name.name not in player_stats:
+                player_stats[name.name] = PlayerHistoricalStats(name)
 
-            team_mmrs[player_name] = player_stats[player_name].mmr
+            team_mmrs[name.name] = player_stats[name.name].mmr
         return team_mmrs
 
     for game in games:
@@ -80,7 +77,7 @@ def track_player_stats(
 
         # handle in game stat updating
         for player_game_stats in game.players:
-            player_name = player_game_stats.playerName
+            player_name = player_game_stats.name.name
 
             # guaranteed playerName is in stats in mmr loop
             player_stats[player_name].add_game(

--- a/scripts/scrape_match_data.py
+++ b/scripts/scrape_match_data.py
@@ -1,8 +1,8 @@
-from lcu_connector import Connector
-from classes.ClientNotOpenException import ClientNotOpenException
-from utils import load_config, get_database_connection
-from constants import CONFIG_PATH
+from scripts.classes.ClientNotOpenException import ClientNotOpenException
+from scripts.utils import load_config, get_database_connection
+from scripts.constants import CONFIG_PATH
 
+from lcu_connector import Connector
 import requests
 import urllib3
 import logging


### PR DESCRIPTION
- Add /register command to allow users to tie a discord account to a riot id
- Make /profile player_name argument optional. If left blank uses the riot id associated with a discord user if it exists
- Migrate to using riot ids instead of summoner names except in cases where the new riot id contains east asian width characters
- Move `inhouse_boy.py` to project home folder for easier debugging. Update imports alongside